### PR TITLE
add support for Gitlab self-hosted servers, closes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Since everything is stored in your browser, you might want to export the data so
 
 1. Clone the repository.
 2. Create an access token from your [gitlab settings](https://gitlab.com/profile/personal_access_tokens). You need to grant it access to `api`, `read_user`, `read_repository` and `read_registry`.
-3. Copy the `env.sample.js` file to `env.js` and replace the empty string with your token.
+3. Copy the `env.sample.js` file to `env.js` and replace the default empty string for token option with your token (for self-hosted servers change the baseUrl option to match your domain).
 4. Use an http server to run the application. There's no build steps required and you don't even need to install the required modules.
 
 ## Future plans

--- a/env.sample.js
+++ b/env.sample.js
@@ -1,3 +1,6 @@
-const token = '';
+const env = {
+	token: '',
+	baseUrl: 'https://gitlab.com', // Looking for self-hosted support? Change this value in your env.js file to match your Gitlab installation domain
+}
 
-export default token;
+export default env;

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -1,12 +1,12 @@
-import token from '../env.js';
+import env from '../env.js';
 
 class Utilities {
 	static async req(api, qs, method = 'GET', headers = {}) {
-		const response = await fetch(`https://gitlab.com/api/v4/${api}?per_page=500`, {
+		const response = await fetch(`${env.baseUrl}/api/v4/${api}?per_page=500`, {
 			method,
 			headers: {
 				...headers,
-				'PRIVATE-TOKEN': token,
+				'PRIVATE-TOKEN': env.token,
 			}
 		});
 		return await response.json();


### PR DESCRIPTION
adding support for Gitlab self-hosted instances by adding the API `baseUrl` as an environment variable in the `env.js` file.

I just tried it with our server and worked like a charm!

PoC :
![image](https://user-images.githubusercontent.com/1621149/73600036-c0f36480-4553-11ea-97fb-8d36dc143ad3.png)

