### PR TITLE
feat: store last updates in log

### DIFF
--- a/scripts/base-component.js
+++ b/scripts/base-component.js
@@ -53,8 +53,10 @@ class Base {
 	}
 
 	updateLastModified() {
-		const lastModified = localStorage.getItem(this.component);
-		document.querySelector(`#${this.component}-update`).innerHTML = lastModified ? timeAgo.format(JSON.parse(lastModified)) : 'Not available';
+		db.logs.get(this.component,(item)=> {
+			document.querySelector(`#${this.component}-update`).innerHTML = item ? 
+				timeAgo.format(JSON.parse(item.last_updated)) : 'Not available';
+		});
 	}
 
 	prepareFilters() {

--- a/scripts/data-handler.js
+++ b/scripts/data-handler.js
@@ -44,6 +44,7 @@ class DataSource {
 		const members = await Members.load(this.data.groups);
 		const key = 'id';
 		this.data.members = [...new Map(members.flat().map(item => [item[key], item])).values()];
+		db.members.bulkPut(this.data.members);
 		db.logs.put({
 			last_updated: Date.now(),
 			id: 'members'

--- a/scripts/data-handler.js
+++ b/scripts/data-handler.js
@@ -19,7 +19,10 @@ class DataSource {
 		const groups = await Groups.load();
 		this.data.groups = groups;
 		db.groups.bulkPut(groups);
-		localStorage.setItem('groups', Date.now());
+		db.logs.put({
+			last_updated: Date.now(),
+			id: 'groups'
+		});
 		return this.data.groups;
 	}
 
@@ -30,7 +33,10 @@ class DataSource {
 			project.group_id = project.namespace.id;
 		});
 		db.projects.bulkPut(this.data.projects);
-		localStorage.setItem('projects', Date.now());
+		db.logs.put({
+			last_updated: Date.now(),
+			id: 'projects'
+		});
 		return this.data.projects;
 	}
 
@@ -38,8 +44,10 @@ class DataSource {
 		const members = await Members.load(this.data.groups);
 		const key = 'id';
 		this.data.members = [...new Map(members.flat().map(item => [item[key], item])).values()];
-		db.members.bulkPut(this.data.members);
-		localStorage.setItem('members', Date.now());
+		db.logs.put({
+			last_updated: Date.now(),
+			id: 'members'
+		});
 		return this.data.members;
 	}
 }

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -10,6 +10,7 @@ db.version(1).stores({
 	events: 'created_at, project_id -> projects.id, author_id -> members.id',
 	member_events: 'id++, member_id -> members.id',
 	commits: 'short_id, author_name -> members.name, authored_date, project_id -> projects.id',
+	logs: 'id'
 });
 
 export default db;


### PR DESCRIPTION
Create new table 'logs' and store last members, groups and projects fetches in it instead of storing it in the local-storage.